### PR TITLE
Migrate from py35 to py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
     - 2.7
-    - 3.5
+    - 3.6
 
 install:
     - pip install codecov

--- a/orchestra/expressions/jinja.py
+++ b/orchestra/expressions/jinja.py
@@ -60,7 +60,7 @@ class JinjaEvaluator(base.Evaluator):
     _regex_dot_extract = '([a-zA-Z0-9_\-]*)'
     _regex_ctx_extract_1 = 'ctx\(\)\.%s' % _regex_dot_extract
     _regex_ctx_extract_2 = 'ctx\([\'|"]?%s(%s)' % (_regex_dot_extract, _regex_dot_pattern)
-    _regex_var_extracts = ['\%s\.?' % _regex_ctx_extract_1, '\%s\.?' % _regex_ctx_extract_2]
+    _regex_var_extracts = ['%s\.?' % _regex_ctx_extract_1, '%s\.?' % _regex_ctx_extract_2]
 
     _block_delimiter = '{%}'
     _regex_block_pattern = '{%.*?%}'

--- a/orchestra/expressions/yql.py
+++ b/orchestra/expressions/yql.py
@@ -59,7 +59,7 @@ class YAQLEvaluator(base.Evaluator):
     _regex_dot_extract = '([a-zA-Z0-9_\-]*)'
     _regex_ctx_extract_1 = 'ctx\(\)\.%s' % _regex_dot_extract
     _regex_ctx_extract_2 = 'ctx\([\'|"]?%s(%s)' % (_regex_dot_extract, _regex_dot_pattern)
-    _regex_var_extracts = ['\%s\.?' % _regex_ctx_extract_1, '\%s\.?' % _regex_ctx_extract_2]
+    _regex_var_extracts = ['%s\.?' % _regex_ctx_extract_1, '%s\.?' % _regex_ctx_extract_2]
 
     _engine = yaql.language.factory.YaqlFactory().create()
     _root_ctx = yaql.create_context()

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py35,py27,pep8,docs
+envlist = py36,py27,pep8,docs
 minversion = 1.6
 skipsdist = True
 
 [travis]
 python =
   2.7: py27, pep8, docs
-  3.5: py35, pep8, docs
+  3.6: py36, pep8, docs
 
 [testenv]
 setenv = VIRTUAL_ENV = {envdir}


### PR DESCRIPTION
StackStorm supports python 3.6. Some tests here passes on python 3.5 but not on 3.6. Move to the same python version to pass tests in StackStorm.