### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/orchestra/utils/specs.py
+++ b/orchestra/utils/specs.py
@@ -25,7 +25,7 @@ def instantiate(spec_type, definition):
         raise ValueError('Workflow definition is empty.')
 
     if isinstance(definition, six.string_types):
-        definition = yaml.load(definition)
+        definition = yaml.safe_load(definition)
 
     if not isinstance(definition, dict):
         raise ValueError('Unable to convert workflow definition into dict.')


### PR DESCRIPTION
Same change as in https://github.com/StackStorm/st2/pull/4223.

There is no need to use `yaml.load` when loading workflow definition files since we only support simple types there (integers, strings, lists, etc.).

`yaml.safe_load` is preferred in such scenarios and `yaml.load` could present security issues since it also supports loading arbitrary Python objects.